### PR TITLE
scale random forest to entire dataset

### DIFF
--- a/video_training.ipynb
+++ b/video_training.ipynb
@@ -16,17 +16,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from keras.applications.inception_v3 import InceptionV3"
    ]
@@ -60,11 +52,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "deep_features_db"
+    "n_frames = deep_features_db.count_documents({})"
    ]
   },
   {
@@ -74,15 +66,6 @@
    "outputs": [],
    "source": [
     "db.collection_names()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#deep_features_db.delete_many({})"
    ]
   },
   {
@@ -191,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_df = pd.DataFrame(list(deep_features_db.find()))"
+    "new_df = pd.DataFrame(list(deep_features_db.find().limit(100)))"
    ]
   },
   {
@@ -209,55 +192,118 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "png_to_numpy(df['movie_title'][0])"
+    "    "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "get_deep_features_for_multiple_frames = lambda frames: np.vstack([get_deep_features(frame) for frame in frames])"
+    "genres = ['Action', 'Adventure', 'Animation', 'Biography', 'Comedy', 'Crime', 'Documentary', 'Drama', 'Family', 'Fantasy', 'Film-Noir','Game-Show','History','Horror','Music','Musical','Mystery','News','Reality-TV','Romance','Sci-Fi','Short','Sport','Thriller','War','Western']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels_and_featuers = pd.concat([movie_train_no_frames, predictions_df], axis=1)"
+    "feature_ids = [str(i) for i in range(2048)]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def split_by_movie(df, test_percentage):\n",
-    "    movie_titles = df['movie_title'].unique()\n",
-    "    test_titles = np.random.choice(movie_titles, size=int(len(movie_titles)//test_percentage), replace=False)\n",
+    "frame_ids = np.empty(shape=(n_frames,), dtype=np.object)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frame_features = np.empty(shape=(n_frames, 2048), dtype=np.float32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frame_genres = np.empty(shape=(n_frames, len(genres)), dtype=np.uint8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, row in enumerate(deep_features_db.find({})):\n",
+    "    for feature_id in feature_ids:\n",
+    "        frame_features[i, int(feature_id)] = row[feature_id]\n",
+    "    frame_ids[i] = row['frame_id']\n",
+    "    for j, genre in enumerate(genres):\n",
+    "        frame_genres[i, j] = row[genre]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def split_by_movie(frame_ids, frame_features, frame_genres, train_pct=0.8, limit=None):\n",
+    "    n = len(frame_ids)\n",
+    "    frame_titles = np.array([frame_id.partition('_')[0] for frame_id in frame_ids], dtype=np.object)\n",
     "\n",
-    "    test_df = df[df['movie_title'].isin(test_titles)]\n",
-    "    train_df = df[~df['movie_title'].isin(test_titles)]\n",
+    "    movie_titles = np.array(list(set(frame_titles)))\n",
+    "    movie_titles\n",
+    "    np.random.shuffle(movie_titles)\n",
+    "\n",
+    "    train_limit = int(len(movie_titles)*train_pct)\n",
+    "\n",
+    "    train_titles = movie_titles[:train_limit]\n",
+    "    test_titles = movie_titles[train_limit:]\n",
+    "\n",
+    "    test_mask = np.isin(frame_titles, test_titles)\n",
+    "    train_mask = ~test_mask\n",
     "    \n",
-    "    genres = df.columns[1:27]\n",
-    "    features_movie_title = df.columns.drop(genres)\n",
+    "    if limit is not None:\n",
+    "        idxs = np.arange(n)\n",
+    "        np.random.shuffle(idxs)\n",
+    "        keep_idxs = idxs[:limit]\n",
+    "        keep_mask = np.zeros(n, dtype=bool)\n",
+    "        keep_mask[keep_idxs] = True\n",
+    "        test_mask = test_mask & keep_mask\n",
+    "        train_mask = train_mask & keep_mask\n",
+    "\n",
+    "    X_train = frame_features[train_mask, :]\n",
+    "    y_train = frame_genres[train_mask, :]\n",
+    "    X_test = frame_features[test_mask, :]\n",
+    "    y_test = frame_genres[test_mask, :]\n",
     "    \n",
-    "    \n",
-    "    #X_train, X_test, y_train, y_test \n",
-    "    return train_df[features_movie_title], test_df[features_movie_title], train_df[genres], test_df[genres]"
+    "    return X_train, X_test, y_train, y_test"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train, X_test, y_train, y_test = split_by_movie(labels_and_featuers, 10)"
+    "X_train, X_test, y_train, y_test = split_by_movie(frame_ids, \n",
+    "                                                  frame_features,\n",
+    "                                                  frame_genres,\n",
+    "                                                  train_pct=0.8,\n",
+    "                                                  )"
    ]
   },
   {
@@ -275,16 +321,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rfc = RandomForestClassifier()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rfc.fit(X_train, y_train)"
+    "rfc = RandomForestClassifier(n_jobs=-1)"
    ]
   },
   {
@@ -300,7 +337,141 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.metrics import classification_report"
+    "rfc.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import classification_report, roc_curve, roc_auc_score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(classification_report(y_test, rfc.predict(X_test)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, y, _ = roc_curve(y_test[:,0], lr.predict_proba(X_test)[:,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roc_auc_score(y_test[:,0], lr.predict_proba(X_test)[:,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "roc_auc_score(y_train[:,0], lr.predict_proba(X_train)[:,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(x, y)\n",
+    "\n",
+    "line_x = np.linspace(0,1)\n",
+    "line_y = line_x\n",
+    "ax.plot(line_x, line_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_of_titles = [frame_id.partition('_')[0] for frame_id in frame_ids]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame({'title': list_of_titles})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['title'].value_counts().hist(bins=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Harry Potter and the Prisoner of Azkaban'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['title'][8453]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = cv2.imread('trailer_test/Harry Potter and the Prisoner of Azkaban0083.png')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cv2.imshow('ImageWindow', img)\n",
+    "cv2.waitKey()"
    ]
   },
   {


### PR DESCRIPTION
Random forest model can be applied to entire dataset by storing it in numpy arrays and refactoring old functions that were made for pandas dataframes.